### PR TITLE
Enable PlatformIO CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run


### PR DESCRIPTION
No CI? Not on my watch.

Gives the repo the green checkmark in the commit line. See [run](https://github.com/maxgerhardt/RP2040-HOTAS/actions/runs/8363892579/job/22897928840) and [docs](https://docs.platformio.org/en/latest/integration/ci/github-actions.html).

You should also add the badge in the `README.md` Markdown after merging.

```text
[![PlatformIO CI](https://github.com/MNS26/RP2040-HOTAS/actions/workflows/build.yml/badge.svg)](https://github.com/MNS26/RP2040-HOTAS/actions/workflows/build.yml)
```